### PR TITLE
Explicitly import React

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,5 @@
 import { ExpoWebGLRenderingContext, GLView, GLViewProps } from "expo-gl";
-import { useState } from "react";
+import React, { useState } from "react";
 import { Gradient, GradientConfig } from "./gradient";
 
 export { Gradient, GradientConfig } from "./gradient";


### PR DESCRIPTION
Sadly, some bundlers complain about this

Ideally, this should be automatic now but alas